### PR TITLE
Encase configuration file in quotes

### DIFF
--- a/office365business/tools/chocolateyInstall.ps1
+++ b/office365business/tools/chocolateyInstall.ps1
@@ -149,13 +149,13 @@ Install-ChocolateyPackage @packageArgs
 # Use the deployment tool to download the setup files
 $packageArgs['packageName'] = 'Office365BusinessInstaller'
 $packageArgs['file'] = "$officetempfolder\Setup.exe"
-$packageArgs['silentArgs'] = "/download $configurationFile"
+$packageArgs['silentArgs'] = "/download `"$configurationFile`""
 Install-ChocolateyInstallPackage @packageArgs
 
 # Run the actual Office setup
 $packageArgs['file'] = "$officetempfolder\Setup.exe"
 $packageArgs['packageName'] = $packageName
-$packageArgs['silentArgs'] = "/configure $configurationFile"
+$packageArgs['silentArgs'] = "/configure `"$configurationFile`""
 Install-ChocolateyInstallPackage @packageArgs
 
 if (Test-Path "$officetempfolder") {

--- a/skypeforbusiness/tools/chocolateyInstall.ps1
+++ b/skypeforbusiness/tools/chocolateyInstall.ps1
@@ -33,7 +33,7 @@ Install-ChocolateyInstallPackage @packageArgs
 # Run the actual Office setup
 $packageArgs['file'] = "$officetempfolder\Setup.exe"
 $packageArgs['packageName'] = $packageName
-$packageArgs['silentArgs'] = "/configure $configurationFile"
+$packageArgs['silentArgs'] = "/configure `"$configurationFile`""
 Install-ChocolateyInstallPackage @packageArgs
 
 if (Test-Path "$officetempfolder") {

--- a/skypeforbusinessbasic/tools/chocolateyInstall.ps1
+++ b/skypeforbusinessbasic/tools/chocolateyInstall.ps1
@@ -27,13 +27,13 @@ Install-ChocolateyPackage @packageArgs
 # Use the deployment tool to download the setup files
 $packageArgs['packageName'] = 'SkypeforBusinessEntryRetail'
 $packageArgs['file'] = "$officetempfolder\Setup.exe"
-$packageArgs['silentArgs'] = "/download $configurationFile `"$officetempfolder\setup.exe`""
+$packageArgs['silentArgs'] = "/download `"$configurationFile`" `"$officetempfolder\setup.exe`""
 Install-ChocolateyInstallPackage @packageArgs
 
 # Run the actual Office setup
 $packageArgs['file'] = "$officetempfolder\Setup.exe"
 $packageArgs['packageName'] = $packageName
-$packageArgs['silentArgs'] = "/configure $configurationFile"
+$packageArgs['silentArgs'] = "/configure `"$configurationFile`""
 Install-ChocolateyInstallPackage @packageArgs
 
 if (Test-Path "$officetempfolder") {


### PR DESCRIPTION
If a configuration file path is specified that has spaces, wrap it in quotes so that `Setup.exe` interprets it correctly.

The installer silently fails if it can't locate the file, and `choco install` proceeds as if nothing had gone wrong.